### PR TITLE
feat: wire pages for RapidAPI access

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # Foot365
+
+Ce projet est un prototype statique d'un site de football.
+
+## Configuration de l'API
+
+1. Ouvrez `config.js` et remplacez `YOUR_RAPIDAPI_KEY` par votre clé RapidAPI.
+2. Les pages chargent `config.js` et `api.js` afin de pouvoir effectuer des requêtes via `fetchData(endpoint)`.
+3. Exemple :
+   ```javascript
+   fetchData('v3/status').then(console.log);
+   ```
+
+Les informations sensibles ne sont pas stockées dans le dépôt ; ajoutez vos clés locales avant le déploiement.
+

--- a/api.js
+++ b/api.js
@@ -1,0 +1,28 @@
+/**
+ * Generic helper to perform requests to RapidAPI.
+ */
+async function fetchData(endpoint) {
+  const url = `https://${window.RAPIDAPI_HOST}/${endpoint}`;
+  const options = {
+    method: 'GET',
+    headers: {
+      'X-RapidAPI-Key': window.RAPIDAPI_KEY,
+      'X-RapidAPI-Host': window.RAPIDAPI_HOST
+    }
+  };
+
+  try {
+    const response = await fetch(url, options);
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('API request failed:', error);
+    return null;
+  }
+}
+
+// Expose helper globally for all pages
+window.fetchData = fetchData;
+

--- a/clubs.html
+++ b/clubs.html
@@ -49,5 +49,7 @@
   <footer>
     <p>&copy; 2024 Foot365</p>
   </footer>
+  <script src="config.js"></script>
+  <script src="api.js"></script>
 </body>
 </html>

--- a/comparateurs.html
+++ b/comparateurs.html
@@ -42,5 +42,7 @@
   <footer>
     <p>&copy; 2024 Foot365</p>
   </footer>
+  <script src="config.js"></script>
+  <script src="api.js"></script>
 </body>
 </html>

--- a/config.js
+++ b/config.js
@@ -1,0 +1,7 @@
+/**
+ * Configuration for RapidAPI access.
+ * Replace 'YOUR_RAPIDAPI_KEY' with your actual RapidAPI key.
+ */
+window.RAPIDAPI_KEY = 'YOUR_RAPIDAPI_KEY';
+window.RAPIDAPI_HOST = 'api-football-v1.p.rapidapi.com';
+

--- a/index.html
+++ b/index.html
@@ -70,5 +70,7 @@
   <footer>
     <p>&copy; 2024 Foot365</p>
   </footer>
+  <script src="config.js"></script>
+  <script src="api.js"></script>
 </body>
 </html>

--- a/joueurs.html
+++ b/joueurs.html
@@ -41,5 +41,7 @@
   <footer>
     <p>&copy; 2024 Foot365</p>
   </footer>
+  <script src="config.js"></script>
+  <script src="api.js"></script>
 </body>
 </html>

--- a/pedagogie.html
+++ b/pedagogie.html
@@ -41,5 +41,7 @@
   <footer>
     <p>&copy; 2024 Foot365</p>
   </footer>
+  <script src="config.js"></script>
+  <script src="api.js"></script>
 </body>
 </html>

--- a/propos.html
+++ b/propos.html
@@ -33,5 +33,7 @@
   <footer>
     <p>&copy; 2024 Foot365</p>
   </footer>
+  <script src="config.js"></script>
+  <script src="api.js"></script>
 </body>
 </html>

--- a/recherche.html
+++ b/recherche.html
@@ -38,5 +38,7 @@
   <footer>
     <p>&copy; 2024 Foot365</p>
   </footer>
+  <script src="config.js"></script>
+  <script src="api.js"></script>
 </body>
 </html>

--- a/scouting.html
+++ b/scouting.html
@@ -39,5 +39,7 @@
   <footer>
     <p>&copy; 2024 Foot365</p>
   </footer>
+  <script src="config.js"></script>
+  <script src="api.js"></script>
 </body>
 </html>

--- a/tendances.html
+++ b/tendances.html
@@ -49,5 +49,7 @@
   <footer>
     <p>&copy; 2024 Foot365</p>
   </footer>
+  <script src="config.js"></script>
+  <script src="api.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `config.js` and `api.js` for RapidAPI usage
- include scripts across all site pages
- document API setup in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68961e0973f88325b4cd01894d6026c3